### PR TITLE
Max turbo pressure monitor + LongPress to clear MaxValues + minor version increase

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 
 def versionMajor = 0
 def versionMinor = 88
-def versionPatch = 2
+def versionPatch = 3
 
 android {
     compileSdkVersion 28

--- a/app/src/main/java/com/mqbcoding/stats/BoostPressureMonitor.java
+++ b/app/src/main/java/com/mqbcoding/stats/BoostPressureMonitor.java
@@ -1,0 +1,140 @@
+package com.mqbcoding.stats;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Handler;
+import android.preference.PreferenceManager;
+import android.provider.Settings;
+import android.support.v4.app.NotificationCompat;
+import android.util.Log;
+
+import com.google.android.apps.auto.sdk.notification.CarNotificationExtender;
+
+import java.util.Date;
+import java.util.Map;
+
+public class BoostPressureMonitor implements CarStatsClientTweaked.Listener {
+    private static final String TAG = "BoostPressureMonitor";
+
+    public static final String PREF_ENABLED = "engineTempMonitoringActive";
+    public static final String PREF_MAX_BOOST_PRESSURE = "maxBoostPressure";
+
+    private static final int NOTIFICATION_ID = 3;
+
+    private static final int NOTIFICATION_TIMEOUT_MS = 60000;
+
+    private static final float HYSTERESIS = 1;
+
+    private final Handler mHandler;
+    private final NotificationManager mNotificationManager;
+
+    private final Context mContext;
+    private boolean mIsEnabled;
+    private float mMaxPressure;
+    private float mTorqueTurboPressure;
+
+    enum State {
+        UNKNOWN,
+        TURBO_PRESSURE_NOMINAL,
+        TURBO_PRESSURE_EXCEEDED
+    }
+
+    private State mState = State.UNKNOWN;
+
+    public BoostPressureMonitor(Context context, Handler handler) {
+        super();
+
+        mNotificationManager =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        mHandler = handler;
+        mContext = context;
+
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+        sharedPreferences.registerOnSharedPreferenceChangeListener(mPreferencesListener);
+        readPreferences(sharedPreferences);
+    }
+
+    private void readPreferences(SharedPreferences preferences) {
+        mIsEnabled = preferences.getBoolean(PREF_ENABLED, true);
+        mMaxPressure = Float.parseFloat(preferences.getString(PREF_MAX_BOOST_PRESSURE, "20"));
+        if (!mIsEnabled) {
+            mHandler.post(mDismissNotification);
+            mState = State.UNKNOWN;
+        }
+    }
+
+    private final SharedPreferences.OnSharedPreferenceChangeListener mPreferencesListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
+        @Override
+        public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String s) {
+            readPreferences(sharedPreferences);
+        }
+    };
+
+    private final Runnable mDismissNotification = new Runnable() {
+        @Override
+        public void run() {
+            Log.d(TAG, "Dismissing boost pressure notification");
+            mNotificationManager.cancel(TAG, NOTIFICATION_ID);
+        }
+    };
+
+    private void notifyBoostPressureExceeded(String text, int icon) {
+        String title = mContext.getString(R.string.notification_boost_pressure_title);
+
+        Notification notification = new NotificationCompat.Builder(mContext, CarStatsService.NOTIFICATION_CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_warning_24dp)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setAutoCancel(true)
+                .setSound(Settings.System.DEFAULT_NOTIFICATION_URI)
+                .extend(new CarNotificationExtender.Builder()
+                        .setTitle(title)
+                        .setSubtitle(text)
+                        .setActionIconResId(icon)
+                        .setThumbnail(CarUtils.getCarBitmap(mContext, R.drawable.ic_warning_24dp,
+                                R.color.car_primary, 128))
+                        .setShouldShowAsHeadsUp(true)
+                        .build())
+                .build();
+        mNotificationManager.notify(TAG, NOTIFICATION_ID, notification);
+        mHandler.postDelayed(mDismissNotification, NOTIFICATION_TIMEOUT_MS);
+
+        CarNotificationSoundPlayer soundPlayer = new CarNotificationSoundPlayer(mContext, R.raw.light);
+        soundPlayer.play();
+    }
+
+    @Override
+    public void onNewMeasurements(String provider, Date timestamp, Map<String, Object> values) {
+        if (!mIsEnabled) {
+            return;
+        }
+
+        Float coolantTemp = mTorqueTurboPressure;
+
+        if (mState == State.UNKNOWN) {
+            mState = State.TURBO_PRESSURE_NOMINAL;
+        } else if (mState != State.TURBO_PRESSURE_NOMINAL && mTorqueTurboPressure > mMaxPressure) {
+            mState = State.TURBO_PRESSURE_EXCEEDED;
+            notifyBoostPressureExceeded(mContext.getString(R.string.notification_exceeded_boost_pressure_text, String.valueOf(mTorqueTurboPressure)), R.drawable.ic_warning_24dp);
+        } else if (mState == State.TURBO_PRESSURE_EXCEEDED && mTorqueTurboPressure < (mMaxPressure - HYSTERESIS)) {
+            mState = State.TURBO_PRESSURE_NOMINAL;
+        }
+    }
+
+    @Override
+    public void onSchemaChanged() {
+        // do nothing
+    }
+
+    public void updateTorqueTurboPressure(float mTorqueTurboPressure) {
+        this.mTorqueTurboPressure = mTorqueTurboPressure;
+    }
+
+    public synchronized void close() {
+        mHandler.post(mDismissNotification);
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(mContext);
+        sharedPreferences.unregisterOnSharedPreferenceChangeListener(mPreferencesListener);
+    }
+}

--- a/app/src/main/java/com/mqbcoding/stats/BoostPressureMonitor.java
+++ b/app/src/main/java/com/mqbcoding/stats/BoostPressureMonitor.java
@@ -25,7 +25,7 @@ public class BoostPressureMonitor implements CarStatsClientTweaked.Listener {
 
     private static final int NOTIFICATION_TIMEOUT_MS = 60000;
 
-    private static final float HYSTERESIS = 1;
+    private static final float HYSTERESIS = 2;
 
     private final Handler mHandler;
     private final NotificationManager mNotificationManager;
@@ -111,11 +111,9 @@ public class BoostPressureMonitor implements CarStatsClientTweaked.Listener {
             return;
         }
 
-        Float coolantTemp = mTorqueTurboPressure;
-
         if (mState == State.UNKNOWN) {
             mState = State.TURBO_PRESSURE_NOMINAL;
-        } else if (mState != State.TURBO_PRESSURE_NOMINAL && mTorqueTurboPressure > mMaxPressure) {
+        } else if (mState == State.TURBO_PRESSURE_NOMINAL && mTorqueTurboPressure > mMaxPressure) {
             mState = State.TURBO_PRESSURE_EXCEEDED;
             notifyBoostPressureExceeded(mContext.getString(R.string.notification_exceeded_boost_pressure_text, String.valueOf(mTorqueTurboPressure)), R.drawable.ic_warning_24dp);
         } else if (mState == State.TURBO_PRESSURE_EXCEEDED && mTorqueTurboPressure < (mMaxPressure - HYSTERESIS)) {

--- a/app/src/main/java/com/mqbcoding/stats/CarStatsClientTweaked.java
+++ b/app/src/main/java/com/mqbcoding/stats/CarStatsClientTweaked.java
@@ -27,12 +27,12 @@ public class CarStatsClientTweaked {
     private static final String TAG = "CarStatsClient";
     private static final String ACTION_CAR_STATS_PROVIDER = "com.github.martoreto.aauto.vex.CAR_STATS_PROVIDER";
     private Context mContext;
-    private Map<String, ServiceConnection> mServiceConnections = new HashMap();
-    private Map<String, ICarStats> mProviders = new HashMap();
-    private List<String> mProvidersByPriority = new ArrayList();
-    private Map<String, String> mProvidersByKey = new HashMap();
-    private Map<String, ICarStatsListener> mRemoteListeners = new HashMap();
-    private List<Listener> mListeners = new ArrayList();
+    private Map<String, ServiceConnection> mServiceConnections = new HashMap<String, ServiceConnection>();
+    private Map<String, ICarStats> mProviders = new HashMap<String, ICarStats>();
+    private List<String> mProvidersByPriority = new ArrayList<String>();
+    private Map<String, String> mProvidersByKey = new HashMap<String, String>();
+    private Map<String, ICarStatsListener> mRemoteListeners = new HashMap<String, ICarStatsListener>();
+    private List<Listener> mListeners = new ArrayList<Listener>();
     private Map<String, FieldSchema> mSchema = Collections.emptyMap();
 
     public CarStatsClientTweaked(Context context) {
@@ -120,8 +120,8 @@ public class CarStatsClientTweaked {
 
     @SuppressWarnings("unchecked")
     private synchronized void updateSchema() {
-        Map<String, FieldSchema> schema = new HashMap();
-        Map<String, String> providersByKey = new HashMap();
+        Map<String, FieldSchema> schema = new HashMap<String, FieldSchema>();
+        Map<String, String> providersByKey = new HashMap<String, String>();
         Iterator var3 = this.mProvidersByPriority.iterator();
 
         while(var3.hasNext()) {
@@ -209,7 +209,7 @@ public class CarStatsClientTweaked {
     }
     @SuppressWarnings("unchecked")
     public Map<String, Object> getMergedMeasurements() {
-        Map<String, Object> measurements = new HashMap();
+        Map<String, Object> measurements = new HashMap<String, Object>();
         Iterator var2 = this.mProviders.entrySet().iterator();
 
         while(var2.hasNext()) {
@@ -246,7 +246,7 @@ public class CarStatsClientTweaked {
 
     public static Collection<Intent> getProviderIntents(Context context) {
         Collection<ResolveInfo> resolveInfos = getProviderInfos(context);
-        List<Intent> intents = new ArrayList(resolveInfos.size());
+        List<Intent> intents = new ArrayList<Intent>(resolveInfos.size());
         Iterator var3 = resolveInfos.iterator();
 
         while(var3.hasNext()) {

--- a/app/src/main/java/com/mqbcoding/stats/CarStatsService.java
+++ b/app/src/main/java/com/mqbcoding/stats/CarStatsService.java
@@ -29,6 +29,7 @@ public class CarStatsService extends CarModeService {
     private CarStatsClientTweaked mStatsClient;
     private CarStatsLogger mStatsLogger;
     private EngineTempMonitor mEngineTempMonitor;
+    private BoostPressureMonitor mBoostPressureMonitor;
     private EngineSpeedMonitor mEngineSpeedMonitor;
     private WheelStateMonitor mWheelStateMonitor;
 
@@ -44,6 +45,9 @@ public class CarStatsService extends CarModeService {
         }
         EngineTempMonitor getEngineTempMonitor() {
             return mEngineTempMonitor;
+        }
+        BoostPressureMonitor getBoostPressureMonitor() {
+            return mBoostPressureMonitor;
         }
         WheelStateMonitor getWheelStateMonitor() {
             return mWheelStateMonitor;
@@ -75,6 +79,9 @@ public class CarStatsService extends CarModeService {
 
         mEngineTempMonitor = new EngineTempMonitor(this, new Handler());
         mStatsClient.registerListener(mEngineTempMonitor);
+
+        mBoostPressureMonitor = new BoostPressureMonitor(this, new Handler());
+        mStatsClient.registerListener(mBoostPressureMonitor);
 
         mEngineSpeedMonitor = new EngineSpeedMonitor(this,new Handler());
         mStatsClient.registerListener(mEngineSpeedMonitor);
@@ -138,6 +145,10 @@ public class CarStatsService extends CarModeService {
         if (mEngineTempMonitor != null) {
             mEngineTempMonitor.close();
             mEngineTempMonitor = null;
+        }
+        if (mBoostPressureMonitor != null) {
+            mBoostPressureMonitor.close();
+            mBoostPressureMonitor = null;
         }
         if (mEngineSpeedMonitor != null) {
             mEngineSpeedMonitor.close();

--- a/app/src/main/java/com/mqbcoding/stats/DashboardFragment.java
+++ b/app/src/main/java/com/mqbcoding/stats/DashboardFragment.java
@@ -163,11 +163,9 @@ public class DashboardFragment extends CarFragment {
     }
 
 
-    // todo: reset min/max when clock is touched
-
-    private final View.OnClickListener resetMinMax = new View.OnClickListener() {
+    private final View.OnLongClickListener resetMinMax = new View.OnLongClickListener() {
         @Override
-        public void onClick(View v) {
+        public boolean onLongClick(View v) {
 
             MaxspeedLeft[dashboardNum] = 0;
             MaxspeedCenter[dashboardNum] = 0;
@@ -185,6 +183,7 @@ public class DashboardFragment extends CarFragment {
             mTextMaxCenter.setText(String.format(Locale.US, FORMAT_DECIMALS, speedCenter));
             mTextMaxRight.setText(String.format(Locale.US, FORMAT_DECIMALS, speedRight));
 
+            return true;
         }
     };
 
@@ -474,6 +473,10 @@ public class DashboardFragment extends CarFragment {
         mConstraintClockRight.setOnClickListener(toggleView);
         mBtnPrev.setOnClickListener(toggleView);
         mBtnNext.setOnClickListener(toggleView);
+
+        //longClick
+        mGraphCenter.setOnLongClickListener(resetMinMax);
+        mConstraintClockCenter.setOnLongClickListener(resetMinMax);
     }
 
     private void setupTypeface(String selectedFont) {
@@ -1411,7 +1414,7 @@ public class DashboardFragment extends CarFragment {
 
     public void updateTorqueMonitors() {
         final long TORQUE_COOLANT_PID = 5l;
-        final long TORQUE_BOOST_PRESSURE_PID = new BigInteger("0xff1202", 16).longValue();
+        final long TORQUE_BOOST_PRESSURE_PID = new BigInteger("ff1202", 16).longValue();
 
         float engineTemp, boostPressure;
 

--- a/app/src/main/java/com/mqbcoding/stats/DashboardFragment.java
+++ b/app/src/main/java/com/mqbcoding/stats/DashboardFragment.java
@@ -71,6 +71,7 @@ public class DashboardFragment extends CarFragment {
     private Timer updateTimer;
     private CarStatsClientTweaked mStatsClient;
     private EngineTempMonitor mEngineTempMonitor;
+    private BoostPressureMonitor mBoostPressureMonitor;
     private Speedometer mClockLeft, mClockCenter, mClockRight;
     private Speedometer mClockMaxLeft, mClockMaxCenter, mClockMaxRight;
     private RaySpeedometer mRayLeft, mRayCenter, mRayRight;
@@ -257,6 +258,7 @@ public class DashboardFragment extends CarFragment {
             Log.i(TAG, "ServiceConnected");
             mStatsClient = carStatsBinder.getStatsClient();
             mEngineTempMonitor = carStatsBinder.getEngineTempMonitor();
+            mBoostPressureMonitor = carStatsBinder.getBoostPressureMonitor();
             mLastMeasurements = mStatsClient.getMergedMeasurements();
             mStatsClient.registerListener(mCarStatsListener);
             doUpdate();
@@ -1316,7 +1318,7 @@ public class DashboardFragment extends CarFragment {
         }
 
         //Update Torque Coolant Temp in Monitor
-        updateEngineMonitor();
+        updateTorqueMonitors();
 
         // Update Title - always!!!
         updateTitle();
@@ -1407,13 +1409,20 @@ public class DashboardFragment extends CarFragment {
     }
 
 
-    public void updateEngineMonitor() {
+    public void updateTorqueMonitors() {
         final long TORQUE_COOLANT_PID = 5l;
+        final long TORQUE_BOOST_PRESSURE_PID = new BigInteger("0xff1202", 16).longValue();
+
+        float engineTemp, boostPressure;
 
         try {
             if (mEngineTempMonitor != null && torqueService != null) {
-                float torqueData = torqueService.getValueForPid(TORQUE_COOLANT_PID, true);
-                mEngineTempMonitor.updateTorqueCoolantTemp(torqueData);
+                engineTemp = torqueService.getValueForPid(TORQUE_COOLANT_PID, true);
+                mEngineTempMonitor.updateTorqueCoolantTemp(engineTemp);
+            }
+            if (mBoostPressureMonitor != null && torqueService != null) {
+                boostPressure = torqueService.getValueForPid(TORQUE_BOOST_PRESSURE_PID, true);
+                mBoostPressureMonitor.updateTorqueTurboPressure(boostPressure);
             }
         } catch (Exception e) {
             Log.e(TAG, "Error: " + e.getMessage());
@@ -1830,7 +1839,6 @@ public class DashboardFragment extends CarFragment {
             case "exlap-Nav_Heading": // this is a compass, so a little bit more is needed to setup the clock
                 setupClock(icon, "ic_heading", "", clock, false, "°", 0, 360, "integer", "integer");
                 clock.setMarkColor(Color.parseColor("#00FFFFFF"));
-
                 //set the degrees so it functions as a circle
                 clock.setStartDegree(270);
                 clock.setEndDegree(630);

--- a/app/src/main/java/com/mqbcoding/stats/SettingsFragment.java
+++ b/app/src/main/java/com/mqbcoding/stats/SettingsFragment.java
@@ -222,6 +222,7 @@ public class SettingsFragment extends PreferenceFragment {
         bindPreferenceSummaryToValue(findPreference("bigqueryTable"));
         bindPreferenceSummaryToValue(findPreference("minOperationalTempThreshold"));
         bindPreferenceSummaryToValue(findPreference("maxOperationTempThreshold"));
+        bindPreferenceSummaryToValue(findPreference("maxBoostPressure"));
         bindPreferenceSummaryToValue(findPreference("fueltanksize"));
         bindPreferenceSummaryToValue(findPreference("performanceTitle1"));
         bindPreferenceSummaryToValue(findPreference("performanceTitle2"));

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -46,6 +46,8 @@
     <string name="notification_engine_temp_text">Se alcanzó la temperatura de trabajo del motor.</string>
     <string name="notification_high_engine_temp_text">Temperatura del motor MUY alta!! !</string>
     <string name="notification_engine_temp_title">Temperatura del motor</string>
+    <string name="notification_boost_pressure_title">Presión del turbo</string>
+    <string name="notification_exceeded_boost_pressure_text">Presión del turbo excedida!! ! %1$s psi.</string>
     <string name="pref_appearance">Apariencia</string>
     <string name="pref_bigquery_dataset_title">Nombre del dato</string>
     <string name="pref_bigquery_project_id_title">Nombre del proyecto</string>
@@ -72,6 +74,8 @@
     <string name="pref_list_providers_title">Mostrar proveedores</string>
     <string name="pref_logging_category_title">Registro de datos</string>
     <string name="pref_notifications_category_title">Notificaciones</string>
+    <string name="pref_fuel_tank_size">Capacidad del tanque de combustible</string>
+    <string name="pref_max_boost_pressure">Presión máxima del turbo</string>
     <string name="pref_engine_temp_monitoring_summary">Mostrar notificación cuando se alcance la temperatura operacional del motor.</string>
     <string name="pref_engine_temp_monitoring_title">Monitor de temperatura del motor</string>
     <string name="pref_engine_temp_threshold_title">Temperatura operacional del motor</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,9 @@
     <string name="notification_engine_temp_text">Engine reached the working temperature.</string>
     <string name="notification_high_engine_temp_text">Engine temp is above MAX!! !</string>
     <string name="notification_engine_temp_title">Engine temperature</string>
+    <string name="notification_boost_pressure_title">Boost pressure</string>
+    <string name="notification_exceeded_boost_pressure_text">Boost pressure exceeded!! ! %1$s psi.</string>
+
     <string name="notification_service_text">Logging is active.</string>
 
     <string name="pref_ambient">Ambient colors</string>
@@ -310,6 +313,7 @@
     <string name="pref_dataelementsettings_4">Dashboard consumption</string>
     <string name="pref_dataelementsettings_5">Dashboard service</string>
     <string name="pref_fuel_tank_size">Fuel tank size</string>
+    <string name="pref_max_boost_pressure">Max boost pressure</string>
     <string name="pref_title_performance_1">Title 1</string>
     <string name="pref_title_performance_2">Title 2</string>
     <string name="pref_title_performance_3">Title 3</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -554,6 +554,11 @@
             android:inputType="number"
             android:key="maxOperationTempThreshold"
             android:title="@string/pref_max_op_temp_threshold_title" />
+        <EditTextPreference
+            android:defaultValue="30"
+            android:inputType="number"
+            android:key="maxBoostPressure"
+            android:title="@string/pref_max_boost_pressure" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="wheelStateMonitoringActive"

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -555,8 +555,8 @@
             android:key="maxOperationTempThreshold"
             android:title="@string/pref_max_op_temp_threshold_title" />
         <EditTextPreference
-            android:defaultValue="30"
-            android:inputType="number"
+            android:defaultValue="20"
+            android:inputType="numberSigned|numberDecimal"
             android:key="maxBoostPressure"
             android:title="@string/pref_max_boost_pressure" />
         <CheckBoxPreference


### PR DESCRIPTION
- Agrego la lógica para poder configurar una presión máxima del turbo y lanzar una notificación
- Hago que el longPress del reloj central resetee los maxValues de los relojes
- Fixes code warnings
- Subo el minor a 3